### PR TITLE
Reuse curl handle

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -64,19 +64,21 @@ get_charset <- function(html_text)
 # get_html_as_text -------------------------------------------------------------
 
 #' Get HTML as Text
+#' 
 #' @param url url
+#' @param handle passed to \code{\link[httr]{GET}}
 #' @param dbg dbg
 #' @keywords internal
 #' @noMd
 #' @noRd
 #' @importFrom httr content
 #' @importFrom kwb.utils catAndRun
-get_html_as_text <- function(url, dbg = TRUE)
+get_html_as_text <- function(url, handle = NULL, dbg = TRUE)
 {
   msg <- sprintf("Getting HTML text from '%s'", kwb.utils::shorten(url, 50L))
   
   kwb.utils::catAndRun(msg, dbg = dbg, expr = {
-    httr_get_or_fail(url) %>%
+    httr_get_or_fail(url, handle) %>%
       httr::content(as = "text")
   })
 }
@@ -88,13 +90,14 @@ get_html_as_text <- function(url, dbg = TRUE)
 #' The function stops with error if the GET request returns status != 200
 #' 
 #' @param url URL to which to send a GET request
+#' @param handle passed to \code{\link[httr]{GET}}
 #' @return If the status was not 200, the function returns what 
 #' \code{\link[httr]{GET}} returned
 #' @importFrom httr GET status_code
 #' @export
-httr_get_or_fail <- function(url)
+httr_get_or_fail <- function(url, handle = NULL)
 {
-  response <- httr::GET(url)
+  response <- httr::GET(url, handle = handle)
   
   if (httr::status_code(response) != "200") {
     stop(sprintf("Request '%s' failed", url))

--- a/man/httr_get_or_fail.Rd
+++ b/man/httr_get_or_fail.Rd
@@ -4,10 +4,12 @@
 \alias{httr_get_or_fail}
 \title{GET Request with Check for Error}
 \usage{
-httr_get_or_fail(url)
+httr_get_or_fail(url, handle = NULL)
 }
 \arguments{
 \item{url}{URL to which to send a GET request}
+
+\item{handle}{passed to \code{\link[httr]{GET}}}
 }
 \value{
 If the status was not 200, the function returns what

--- a/man/read_all_metadata.Rd
+++ b/man/read_all_metadata.Rd
@@ -4,11 +4,19 @@
 \alias{read_all_metadata}
 \title{Read Metadata based on Overview on FIS Broker Datasets}
 \usage{
-read_all_metadata(overview = get_dataset_overview(), dbg = TRUE)
+read_all_metadata(
+  overview = get_dataset_overview(),
+  preserve_handle = TRUE,
+  dbg = TRUE
+)
 }
 \arguments{
 \item{overview}{overview tibble as retrieved by \code{\link{get_dataset_overview}},
 (default: \code{\link{get_dataset_overview}})}
+
+\item{preserve_handle}{logical. If TRUE (the default is FALSE), the Curl
+handle is created in advance and reused for all \code{\link[httr]{GET}}
+requests.}
 
 \item{dbg}{whether or not to show debug messages (default: TRUE)}
 }

--- a/man/read_metadata.Rd
+++ b/man/read_metadata.Rd
@@ -9,7 +9,8 @@ read_metadata(
   service_type = "WFS",
   encoding = "Windows-1252",
   dbg = TRUE,
-  url = NULL
+  url = NULL,
+  handle = NULL
 )
 }
 \arguments{


### PR DESCRIPTION
Reusing the Curl handle slightly improves performance:

```
system.time(
  md1 <- kwb.fisbroker::read_all_metadata(overview, preserve_handle = FALSE)
)
#  User      System verstrichen 
# 40.65        0.57      182.23 

system.time(
  md2 <- kwb.fisbroker::read_all_metadata(overview, preserve_handle = TRUE)
)
#  User      System verstrichen 
# 36.60        0.47      150.26

identical(md1, md2) # TRUE
```

Also: Convert columns `section`, `parameter` to factor for better filtering in RStudio data viewer